### PR TITLE
add data directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 **/*.rs.bk
 
 .DS_Store
+
+/data/


### PR DESCRIPTION
I added this in order to prevent the deletion of the shareware assets when pulling from main.