### PR TITLE
Extract some components from the raycaster

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,3 +1,4 @@
+use crate::constants::{MAP_HEIGHT, MAP_WIDTH};
 use crate::map;
 use crate::map::Map;
 use std::fs;
@@ -530,9 +531,9 @@ fn get_plane(data: &[u8], offset: i32, length: u16, magic_rlew_word: &[u8; 2]) -
     let mut bytes = bytes
         .chunks_exact(2)
         .map(|word| u16::from_le_bytes(word.try_into().unwrap()));
-    let mut result = [[0; map::HEIGHT]; map::WIDTH];
-    for y in 0..map::HEIGHT {
-        for x in result.iter_mut().take(map::WIDTH) {
+    let mut result = [[0; MAP_HEIGHT]; MAP_WIDTH];
+    for y in 0..MAP_HEIGHT {
+        for x in result.iter_mut().take(MAP_WIDTH) {
             x[y] = bytes.next().unwrap();
         }
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,3 +10,9 @@ pub const ANGLE_DOWN: f64 = 0.0;
 pub const ANGLE_UP: f64 = PI;
 pub const ANGLE_LEFT: f64 = 3.0 * PI / 2.0;
 pub const ANGLE_RIGHT: f64 = PI / 2.0;
+
+// ok this is not a constant, we may move it to an util module later, or rename this
+pub fn norm_angle(a: f64) -> f64 {
+    let nrots = (a / (2.0 * PI)).trunc() - if a < 0.0 { 1.0 } else { 0.0 };
+    a - nrots * 2.0 * PI
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,12 @@
+use std::f64::consts::PI;
+
+pub const MAP_WIDTH: usize = 64;
+pub const MAP_HEIGHT: usize = 64;
+pub const WIDTH_2D: u32 = 1024;
+pub const HEIGHT_2D: u32 = 1024;
+pub const MAP_SCALE_H: u32 = HEIGHT_2D / MAP_HEIGHT as u32;
+pub const MAP_SCALE_W: u32 = WIDTH_2D / MAP_WIDTH as u32;
+pub const ANGLE_DOWN: f64 = 0.0;
+pub const ANGLE_UP: f64 = PI;
+pub const ANGLE_LEFT: f64 = 3.0 * PI / 2.0;
+pub const ANGLE_RIGHT: f64 = PI / 2.0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,6 @@ pub fn main() {
     canvas.copy(&texture, None, None).unwrap();
     canvas.present();
 
-    ray_caster.tick(map, &mut event_pump).unwrap_or_default(); // TODO: can we ignore any error or do we need to handle it?
     ray_caster.wait_for_key(&mut event_pump);
 
     'main_loop: loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use sdl2::rect::Rect;
 use sdl2::render::{RenderTarget, Texture};
 use sdl2::video::WindowContext;
 use sdl2::EventPump;
+use std::time::Duration;
 use std::time::Instant;
 
 use clap::Parser;
@@ -101,12 +102,17 @@ pub fn main() {
     wait_for_key(&mut event_pump);
 
     'main_loop: loop {
-        let ray_hits = match ray_caster.tick(map, &mut event_pump) {
+        match ray_caster.process_input(&mut event_pump) {
             Ok(hits) => hits,
             Err(_) => {
                 break 'main_loop;
             }
         };
+
+        let ray_hits = ray_caster.tick(map);
+
+        // FIXME is this really necessary or can it be handled by sdl
+        ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));
 
         // fake walls
         let mut texture = texture_creator

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,10 @@ use clap::Parser;
 
 mod cache;
 type ColorMap = [(u8, u8, u8); 256];
+mod constants;
 mod input_manager;
 mod map;
+mod player;
 mod ray_caster;
 
 use crate::ray_caster::RayHit;
@@ -80,8 +82,8 @@ pub fn main() {
     let episode = 0;
     let level = args.level - 1;
     let map = cache.get_map(episode, level);
-
-    let mut ray_caster = ray_caster::RayCaster::init(&sdl_context, map, PIX_WIDTH, PIX_HEIGHT);
+    let mut player = map.find_player();
+    let mut ray_caster = ray_caster::RayCaster::init(&sdl_context, PIX_WIDTH, PIX_HEIGHT);
 
     let window = video_subsystem
         .window("rustenstein 3D", width, height)
@@ -102,14 +104,14 @@ pub fn main() {
     wait_for_key(&mut event_pump);
 
     'main_loop: loop {
-        match ray_caster.process_input(&mut event_pump) {
+        match ray_caster.process_input(&mut event_pump, &mut player) {
             Ok(hits) => hits,
             Err(_) => {
                 break 'main_loop;
             }
         };
 
-        let ray_hits = ray_caster.tick(map);
+        let ray_hits = ray_caster.tick(&player, map);
 
         // FIXME is this really necessary or can it be handled by sdl
         ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,7 @@ pub fn main() {
     let start_time = Instant::now();
     let sdl_context = sdl2::init().unwrap();
     let video_subsystem = sdl_context.video().unwrap();
+    let mut event_pump = sdl_context.event_pump().unwrap();
 
     let color_map = build_color_map();
     let cache = cache::init();
@@ -97,11 +98,11 @@ pub fn main() {
     canvas.copy(&texture, None, None).unwrap();
     canvas.present();
 
-    ray_caster.tick(map).unwrap_or_default(); // TODO: can we ignore any error or do we need to handle it?
-    ray_caster.wait_for_key(map);
+    ray_caster.tick(map, &mut event_pump).unwrap_or_default(); // TODO: can we ignore any error or do we need to handle it?
+    ray_caster.wait_for_key(map, &mut event_pump);
 
     'main_loop: loop {
-        let ray_hits = match ray_caster.tick(map) {
+        let ray_hits = match ray_caster.tick(map, &mut event_pump) {
             Ok(hits) => hits,
             Err(_) => {
                 break 'main_loop;

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,12 +97,19 @@ pub fn main() {
 
     let mut canvas = window.into_canvas().build().unwrap();
     let texture_creator = canvas.texture_creator();
-    let mut texture = texture_creator
+    let mut titlepic_texture = texture_creator
         .create_texture_streaming(PixelFormatEnum::RGB24, 320, 200)
         .unwrap();
-    draw_to_texture(&mut texture, titlepic, color_map);
+    let mut world_texture = texture_creator
+        .create_texture_streaming(PixelFormatEnum::RGB24, PIX_WIDTH, PIX_HEIGHT)
+        .unwrap();
+    let mut status_texture = texture_creator
+        .create_texture_streaming(PixelFormatEnum::RGB24, BASE_WIDTH, BASE_HEIGHT)
+        .unwrap();
 
-    canvas.copy(&texture, None, None).unwrap();
+    draw_to_texture(&mut titlepic_texture, titlepic, color_map);
+
+    canvas.copy(&titlepic_texture, None, None).unwrap();
     canvas.present();
 
     wait_for_key(&mut event_pump);
@@ -120,12 +127,7 @@ pub fn main() {
         // FIXME is this really necessary or can it be handled by sdl
         ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));
 
-        // fake walls
-        let mut texture = texture_creator
-            .create_texture_streaming(PixelFormatEnum::RGB24, PIX_WIDTH, PIX_HEIGHT)
-            .unwrap();
-
-        texture
+        world_texture
             .with_lock(None, |buffer: &mut [u8], pitch: usize| {
                 // draw floor and ceiling colors
                 let floor = color_map[VGA_FLOOR_COLOR];
@@ -177,15 +179,11 @@ pub fn main() {
             .unwrap();
 
         canvas
-            .copy(&texture, None, Rect::new(0, 0, width, view_height))
+            .copy(&world_texture, None, Rect::new(0, 0, width, view_height))
             .unwrap();
 
         // show status picture
-        let mut texture = texture_creator
-            .create_texture_streaming(PixelFormatEnum::RGB24, BASE_WIDTH, BASE_HEIGHT)
-            .unwrap();
-
-        draw_to_texture(&mut texture, statuspic, color_map);
+        draw_to_texture(&mut status_texture, statuspic, color_map);
 
         let face_to_draw = match start_time.elapsed().as_secs() % 3 {
             0 => default_facepic,
@@ -193,12 +191,12 @@ pub fn main() {
             2 => righteye_facepic,
             _ => unreachable!(),
         };
-        draw_face_to_texture(&mut texture, face_to_draw, color_map);
+        draw_face_to_texture(&mut status_texture, face_to_draw, color_map);
 
         // I don't know why I had to *5 for the height
         canvas
             .copy(
-                &texture,
+                &status_texture,
                 None,
                 Rect::new(
                     0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ pub fn main() {
     canvas.present();
 
     ray_caster.tick(map, &mut event_pump).unwrap_or_default(); // TODO: can we ignore any error or do we need to handle it?
-    ray_caster.wait_for_key(map, &mut event_pump);
+    ray_caster.wait_for_key(&mut event_pump);
 
     'main_loop: loop {
         let ray_hits = match ray_caster.tick(map, &mut event_pump) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ pub fn main() {
     canvas.copy(&texture, None, None).unwrap();
     canvas.present();
 
-    ray_caster.wait_for_key(&mut event_pump);
+    wait_for_key(&mut event_pump);
 
     'main_loop: loop {
         let ray_hits = match ray_caster.tick(map, &mut event_pump) {
@@ -198,6 +198,18 @@ pub fn main() {
             .unwrap();
 
         canvas.present();
+    }
+}
+
+// FIXME this is duplicated in input manager. move over there
+pub fn wait_for_key(event_pump: &mut EventPump) {
+    'running: loop {
+        for event in event_pump.poll_iter() {
+            match event {
+                Event::Quit { .. } | Event::KeyDown { .. } => break 'running,
+                _ => {}
+            }
+        }
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,7 +1,6 @@
+use crate::constants::*;
+use crate::player;
 use std::{fmt, fs};
-
-pub const WIDTH: usize = 64;
-pub const HEIGHT: usize = 64;
 
 #[derive(Copy, Clone)]
 pub enum Tile {
@@ -27,15 +26,15 @@ pub enum Actor {
 
 #[derive(Debug)]
 pub struct Map {
-    plane0: [[u16; HEIGHT]; WIDTH],
-    plane1: [[u16; HEIGHT]; WIDTH],
+    plane0: [[u16; MAP_HEIGHT]; MAP_WIDTH],
+    plane1: [[u16; MAP_HEIGHT]; MAP_WIDTH],
     pub name: String,
 }
 
 impl Map {
     pub fn new(
-        plane0: [[u16; HEIGHT]; WIDTH],
-        plane1: [[u16; HEIGHT]; WIDTH],
+        plane0: [[u16; MAP_HEIGHT]; MAP_WIDTH],
+        plane1: [[u16; MAP_HEIGHT]; MAP_WIDTH],
         name: String,
     ) -> Self {
         Self {
@@ -76,9 +75,28 @@ impl Map {
         }
     }
 
+    pub fn find_player(&self) -> player::Player {
+        let (player_x, player_y, player_dir) = self.find_player_start();
+        // TODO not sure why thse /3 and /2 are necessary
+        let player_x = (MAP_SCALE_W * (player_x as u32) + MAP_SCALE_W / 3) as f64;
+        let player_y = (MAP_SCALE_H * (player_y as u32) + MAP_SCALE_H / 2) as f64;
+        let player_angle = match player_dir {
+            Direction::North => ANGLE_UP,
+            Direction::East => ANGLE_RIGHT,
+            Direction::South => ANGLE_DOWN,
+            Direction::West => ANGLE_LEFT,
+        };
+
+        player::Player {
+            x: player_x,
+            y: player_y,
+            angle: player_angle,
+        }
+    }
+
     pub fn find_player_start(&self) -> (u8, u8, Direction) {
-        for x in 0..WIDTH as u8 {
-            for y in 0..HEIGHT as u8 {
+        for x in 0..MAP_WIDTH as u8 {
+            for y in 0..MAP_HEIGHT as u8 {
                 if let Some(Actor::Player(direction)) = self.actor_at(x, y) {
                     return (x, y, direction);
                 }
@@ -90,8 +108,8 @@ impl Map {
 
 impl fmt::Display for Map {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for x in 0..WIDTH {
-            for y in 0..HEIGHT {
+        for x in 0..MAP_WIDTH {
+            for y in 0..MAP_HEIGHT {
                 let word = self.plane0[x][y];
                 if word == 90 {
                     write!(f, "|").unwrap();

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,0 +1,5 @@
+pub struct Player {
+    pub x: f64,
+    pub y: f64,
+    pub angle: f64,
+}

--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -2,7 +2,7 @@ extern crate sdl2;
 
 use num::pow;
 use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
+use sdl2::keyboard::Scancode;
 use sdl2::pixels::Color;
 use sdl2::rect::Point;
 use sdl2::rect::Rect;
@@ -127,50 +127,50 @@ impl RayCaster {
     pub fn tick(&mut self, map: &Map) -> Result<Vec<RayHit>, &str> {
         self.canvas.set_draw_color(Color::RGB(64, 64, 64));
         self.canvas.clear();
-        //TODO: move this code to a sensible location
+
         for event in self.event_pump.poll_iter() {
             match event {
                 Event::Quit { .. }
                 | Event::KeyDown {
-                    keycode: Some(Keycode::Escape),
+                    scancode: Some(Scancode::Escape),
                     ..
                 } => return Err("Goodbye!"),
                 Event::KeyDown {
-                    keycode: Some(Keycode::Left),
+                    scancode: Some(Scancode::Left),
                     ..
                 } => self.left_down = true,
                 Event::KeyUp {
-                    keycode: Some(Keycode::Left),
+                    scancode: Some(Scancode::Left),
                     ..
                 } => {
                     self.left_down = false;
                 }
                 Event::KeyDown {
-                    keycode: Some(Keycode::Right),
+                    scancode: Some(Scancode::Right),
                     ..
                 } => self.right_down = true,
                 Event::KeyUp {
-                    keycode: Some(Keycode::Right),
+                    scancode: Some(Scancode::Right),
                     ..
                 } => {
                     self.right_down = false;
                 }
                 Event::KeyDown {
-                    keycode: Some(Keycode::Up),
+                    scancode: Some(Scancode::Up),
                     ..
                 } => self.up_down = true,
                 Event::KeyUp {
-                    keycode: Some(Keycode::Up),
+                    scancode: Some(Scancode::Up),
                     ..
                 } => {
                     self.up_down = false;
                 }
                 Event::KeyDown {
-                    keycode: Some(Keycode::Down),
+                    scancode: Some(Scancode::Down),
                     ..
                 } => self.down_down = true,
                 Event::KeyUp {
-                    keycode: Some(Keycode::Down),
+                    scancode: Some(Scancode::Down),
                     ..
                 } => {
                     self.down_down = false;

--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -43,7 +43,6 @@ struct Nothing;
 
 pub struct RayCaster {
     canvas: WindowCanvas,
-    event_pump: EventPump,
     player: Player,
     view3d_width: u32,
     view3d_height: u32,
@@ -67,7 +66,6 @@ impl RayCaster {
         canvas_2d.set_draw_color(Color::RGB(0, 255, 255));
         canvas_2d.clear();
         canvas_2d.present();
-        let pump = sdl_context.event_pump().unwrap();
 
         let (player_x, player_y, player_dir) = map.find_player_start();
         // TODO not sure why thse /3 and /2 are necessary
@@ -83,7 +81,6 @@ impl RayCaster {
 
         RayCaster {
             canvas: canvas_2d,
-            event_pump: pump,
             view3d_width,
             view3d_height,
             player: Player {
@@ -94,9 +91,9 @@ impl RayCaster {
         }
     }
 
-    pub fn wait_for_key(&mut self, map: &Map) {
+    pub fn wait_for_key(&mut self, map: &Map, event_pump: &mut EventPump) {
         'running: loop {
-            for event in self.event_pump.poll_iter() {
+            for event in event_pump.poll_iter() {
                 match event {
                     Event::Quit { .. } | Event::KeyDown { .. } => break 'running,
                     _ => {
@@ -116,11 +113,11 @@ impl RayCaster {
         }
     }
 
-    pub fn tick(&mut self, map: &Map) -> Result<Vec<RayHit>, &str> {
+    pub fn tick(&mut self, map: &Map, event_pump: &mut EventPump) -> Result<Vec<RayHit>, &str> {
         self.canvas.set_draw_color(Color::RGB(64, 64, 64));
         self.canvas.clear();
 
-        for event in self.event_pump.poll_iter() {
+        for event in event_pump.poll_iter() {
             if let Event::Quit { .. }
             | Event::KeyDown {
                 scancode: Some(Scancode::Escape),
@@ -131,7 +128,7 @@ impl RayCaster {
             };
         }
 
-        let keyboard = self.event_pump.keyboard_state();
+        let keyboard = event_pump.keyboard_state();
         if keyboard.is_scancode_pressed(Scancode::Left) {
             self.player.angle += ROTATE_SPEED;
         }

--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -91,17 +91,6 @@ impl RayCaster {
         }
     }
 
-    pub fn wait_for_key(&mut self, event_pump: &mut EventPump) {
-        'running: loop {
-            for event in event_pump.poll_iter() {
-                match event {
-                    Event::Quit { .. } | Event::KeyDown { .. } => break 'running,
-                    _ => {}
-                }
-            }
-        }
-    }
-
     pub fn tick(&mut self, map: &Map, event_pump: &mut EventPump) -> Result<Vec<RayHit>, &str> {
         self.canvas.set_draw_color(Color::RGB(64, 64, 64));
         self.canvas.clear();

--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -11,7 +11,6 @@ use sdl2::render::{Canvas, WindowCanvas};
 use sdl2::{EventPump, Sdl};
 use std::cmp::min;
 use std::f64::consts::PI;
-use std::time::Duration;
 
 use crate::map;
 use crate::map::{Direction, Map, Tile};
@@ -91,10 +90,23 @@ impl RayCaster {
         }
     }
 
-    pub fn tick(&mut self, map: &Map, event_pump: &mut EventPump) -> Result<Vec<RayHit>, &str> {
+    pub fn tick(&mut self, map: &Map) -> Vec<RayHit> {
         self.canvas.set_draw_color(Color::RGB(64, 64, 64));
         self.canvas.clear();
+        draw_map(map, &mut self.canvas);
+        let hits = draw_rays(
+            map,
+            &mut self.canvas,
+            &mut self.player,
+            self.view3d_height,
+            self.view3d_width,
+        );
+        draw_player(&mut self.canvas, &mut self.player);
+        self.canvas.present();
+        hits
+    }
 
+    pub fn process_input(&mut self, event_pump: &mut EventPump) -> Result<(), &str> {
         for event in event_pump.poll_iter() {
             if let Event::Quit { .. }
             | Event::KeyDown {
@@ -122,18 +134,7 @@ impl RayCaster {
             self.player.x -= self.player.angle.sin() * MOVE_SPEED;
             self.player.y -= self.player.angle.cos() * MOVE_SPEED;
         }
-        draw_map(map, &mut self.canvas);
-        let hits = draw_rays(
-            map,
-            &mut self.canvas,
-            &mut self.player,
-            self.view3d_height,
-            self.view3d_width,
-        );
-        draw_player(&mut self.canvas, &mut self.player);
-        self.canvas.present();
-        ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));
-        Ok(hits)
+        Ok(())
     }
 }
 

--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -91,23 +91,12 @@ impl RayCaster {
         }
     }
 
-    pub fn wait_for_key(&mut self, map: &Map, event_pump: &mut EventPump) {
+    pub fn wait_for_key(&mut self, event_pump: &mut EventPump) {
         'running: loop {
             for event in event_pump.poll_iter() {
                 match event {
                     Event::Quit { .. } | Event::KeyDown { .. } => break 'running,
-                    _ => {
-                        draw_map(map, &mut self.canvas);
-                        let _hits = draw_rays(
-                            map,
-                            &mut self.canvas,
-                            &mut self.player,
-                            self.view3d_height,
-                            self.view3d_width,
-                        );
-                        draw_player(&mut self.canvas, &mut self.player);
-                        self.canvas.present();
-                    }
+                    _ => {}
                 }
             }
         }

--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -47,10 +47,6 @@ pub struct RayCaster {
     player: Player,
     view3d_width: u32,
     view3d_height: u32,
-    left_down: bool,
-    right_down: bool,
-    up_down: bool,
-    down_down: bool,
 }
 
 pub struct RayHit {
@@ -95,10 +91,6 @@ impl RayCaster {
                 y: player_y,
                 angle: player_angle,
             },
-            left_down: false,
-            right_down: false,
-            up_down: false,
-            down_down: false,
         }
     }
 
@@ -129,67 +121,29 @@ impl RayCaster {
         self.canvas.clear();
 
         for event in self.event_pump.poll_iter() {
-            match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
-                    scancode: Some(Scancode::Escape),
-                    ..
-                } => return Err("Goodbye!"),
-                Event::KeyDown {
-                    scancode: Some(Scancode::Left),
-                    ..
-                } => self.left_down = true,
-                Event::KeyUp {
-                    scancode: Some(Scancode::Left),
-                    ..
-                } => {
-                    self.left_down = false;
-                }
-                Event::KeyDown {
-                    scancode: Some(Scancode::Right),
-                    ..
-                } => self.right_down = true,
-                Event::KeyUp {
-                    scancode: Some(Scancode::Right),
-                    ..
-                } => {
-                    self.right_down = false;
-                }
-                Event::KeyDown {
-                    scancode: Some(Scancode::Up),
-                    ..
-                } => self.up_down = true,
-                Event::KeyUp {
-                    scancode: Some(Scancode::Up),
-                    ..
-                } => {
-                    self.up_down = false;
-                }
-                Event::KeyDown {
-                    scancode: Some(Scancode::Down),
-                    ..
-                } => self.down_down = true,
-                Event::KeyUp {
-                    scancode: Some(Scancode::Down),
-                    ..
-                } => {
-                    self.down_down = false;
-                }
-                _ => {}
-            }
+            if let Event::Quit { .. }
+            | Event::KeyDown {
+                scancode: Some(Scancode::Escape),
+                ..
+            } = event
+            {
+                return Err("Goodbye!");
+            };
         }
-        if self.left_down {
+
+        let keyboard = self.event_pump.keyboard_state();
+        if keyboard.is_scancode_pressed(Scancode::Left) {
             self.player.angle += ROTATE_SPEED;
         }
-        if self.right_down {
+        if keyboard.is_scancode_pressed(Scancode::Right) {
             self.player.angle -= ROTATE_SPEED;
         }
         self.player.angle = norm_angle(self.player.angle);
-        if self.up_down {
+        if keyboard.is_scancode_pressed(Scancode::Up) {
             self.player.x += self.player.angle.sin() * MOVE_SPEED;
             self.player.y += self.player.angle.cos() * MOVE_SPEED;
         }
-        if self.down_down {
+        if keyboard.is_scancode_pressed(Scancode::Down) {
             self.player.x -= self.player.angle.sin() * MOVE_SPEED;
             self.player.y -= self.player.angle.cos() * MOVE_SPEED;
         }

--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -6,7 +6,6 @@ use crate::map::{Direction, Map, Tile};
 use crate::player::Player;
 use num::pow;
 use sdl2::event::Event;
-use sdl2::keyboard::Scancode;
 use sdl2::pixels::Color;
 use sdl2::rect::Point;
 use sdl2::rect::Rect;
@@ -18,8 +17,6 @@ use std::f64::consts::PI;
 
 const PLAYER_DIAM: i32 = 6;
 const PLAYER_LEN: f64 = 40.0;
-const ROTATE_SPEED: f64 = 0.02;
-const MOVE_SPEED: f64 = 2.5;
 const FIELD_OF_VIEW: f64 = PI / 2.0;
 
 const TILE_SIZE: u32 = 4;
@@ -73,41 +70,6 @@ impl RayCaster {
         draw_player(&mut self.canvas, player);
         self.canvas.present();
         hits
-    }
-
-    pub fn process_input(
-        &mut self,
-        event_pump: &mut EventPump,
-        player: &mut Player,
-    ) -> Result<(), &str> {
-        for event in event_pump.poll_iter() {
-            if let Event::Quit { .. }
-            | Event::KeyDown {
-                scancode: Some(Scancode::Escape),
-                ..
-            } = event
-            {
-                return Err("Goodbye!");
-            };
-        }
-
-        let keyboard = event_pump.keyboard_state();
-        if keyboard.is_scancode_pressed(Scancode::Left) {
-            player.angle += ROTATE_SPEED;
-        }
-        if keyboard.is_scancode_pressed(Scancode::Right) {
-            player.angle -= ROTATE_SPEED;
-        }
-        player.angle = norm_angle(player.angle);
-        if keyboard.is_scancode_pressed(Scancode::Up) {
-            player.x += player.angle.sin() * MOVE_SPEED;
-            player.y += player.angle.cos() * MOVE_SPEED;
-        }
-        if keyboard.is_scancode_pressed(Scancode::Down) {
-            player.x -= player.angle.sin() * MOVE_SPEED;
-            player.y -= player.angle.cos() * MOVE_SPEED;
-        }
-        Ok(())
     }
 }
 
@@ -309,11 +271,6 @@ fn cdiv(x: f64, scale: u32, updown: f64) -> usize {
 
 fn ctrunc(x: f64, scale: u32, updown: f64) -> f64 {
     (x / scale as f64 + updown).trunc() * scale as f64
-}
-
-fn norm_angle(a: f64) -> f64 {
-    let nrots = (a / (2.0 * PI)).trunc() - if a < 0.0 { 1.0 } else { 0.0 };
-    a - nrots * 2.0 * PI
 }
 
 fn distance(player: &Player, x: f64, y: f64) -> f64 {


### PR DESCRIPTION
This is step 1 of decoupling components from the ray caster module. For now this:

* Extracts some shared constants
* Extracts the player struct to its own module
* Moves input processing over to main (this should eventually go to its own input processing module)

For now the map window rendering is left inside the ray caster module.