### PR TITLE
fix: prevent distorted cylindrical rendering on flat screen

### DIFF
--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -124,7 +124,7 @@ fn draw_rays<T: RenderTarget>(
     let mut hits: Vec<RayHit> = Vec::new();
     for i in 0..n_rays {
         let fov_angle = fov_delta * (i as f64);
-        // transformation from cylindrical screen to flat screen
+        // transformation from cylindrical screen to flat screen (prevents fisheye effect)
         let offset = (FIELD_OF_VIEW / 2.0 - fov_angle).atan();
 
         let ray_h = cast_ray_h(map, canvas, player, offset);

--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -120,10 +120,13 @@ fn draw_rays<T: RenderTarget>(
     height: u32,
     n_rays: u32,
 ) -> Vec<RayHit> {
-    let step_angle = FIELD_OF_VIEW / (n_rays as f64);
+    let fov_delta = FIELD_OF_VIEW / (n_rays as f64);
     let mut hits: Vec<RayHit> = Vec::new();
     for i in 0..n_rays {
-        let offset = FIELD_OF_VIEW / 2.0 - (i as f64) * step_angle;
+        let fov_angle = fov_delta * (i as f64);
+        // transformation from cylindrical screen to flat screen
+        let offset = (FIELD_OF_VIEW / 2.0 - fov_angle).atan();
+
         let ray_h = cast_ray_h(map, canvas, player, offset);
         let ray_v = cast_ray_v(map, canvas, player, offset);
         let (hit, horiz) = match (ray_h, ray_v) {
@@ -132,6 +135,7 @@ fn draw_rays<T: RenderTarget>(
         };
         draw_ray(canvas, player, hit, Color::WHITE);
         let (_, _, distance, tile) = hit;
+
         let adj_distance = distance * offset.cos();
         let ray_height = (TILE_SIZE * n_rays) as f64 / adj_distance;
         hits.push(RayHit {


### PR DESCRIPTION
Fixed rendering that was incorrectly projecting for cylindrical screen instead of flat screen. This error was causing walls to be curved (most visible at wide FOV when the wall is touching the right/left edge of the screen). Now the walls are completely straight at any FOV.