### PR TITLE
Display wall textures

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -16,6 +16,7 @@ pub const BASE_HEIGHT: u32 = 200;
 pub const PIX_WIDTH: u32 = BASE_WIDTH;
 pub const PIX_HEIGHT: u32 = BASE_HEIGHT - STATUS_LINES;
 pub const PIX_CENTER: u32 = PIX_HEIGHT / 2;
+pub const WALLPIC_WIDTH: usize = 64;
 
 // ok this is not a constant, we may move it to an util module later, or rename this
 pub fn norm_angle(a: f64) -> f64 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,7 @@ pub fn main() {
         let ray_hits = ray_caster.tick(&player, map);
 
         // FIXME is this really necessary or can it be handled by sdl?
-        ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));
+        ::std::thread::sleep(Duration::new(0, 500_000_000u32 / 60));
 
         draw_world(&game, &mut video, &ray_hits);
         draw_weapon(&game, &mut video);

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,21 +214,27 @@ fn draw_world(game: &Game, video: &mut Video, ray_hits: &[RayHit]) {
             }
 
             for x in 0..PIX_WIDTH {
-                let mut color = if ray_hits[x as usize].horizontal {
-                    video.color_map[150]
-                } else {
-                    video.color_map[155]
-                };
+                let hit = &ray_hits[x as usize];
+                // FIXME the selected tiles don't seem to match
+                let texture = game.cache.get_texture(hit.tile as usize+6);
+
                 let current = match ray_hits[x as usize].height {
                     rh if rh > PIX_CENTER => PIX_CENTER,
                     rh => rh,
                 };
-
-                // divide the color by a factor of the height to get a gradient shadow effect based on distance
-                color = darken_color(color, current, PIX_CENTER);
-
+                let xoff = (x % 64) * 64;
+                let step = 32.0 / ray_hits[x as usize].height as f64;
+                let mut ytex = 0.0;
                 for y in PIX_CENTER - current..PIX_CENTER + current {
+                    let source = ytex as u32 + xoff;
+                    let color_index = texture[source as usize] as usize;
+                    let mut color = video.color_map[color_index];
+
+                    // divide the color by a factor of the height to get a gradient shadow effect based on distance
+                    color = darken_color(color, current, PIX_CENTER);
+
                     put_pixel(buffer, pitch, x, y, color);
+                    ytex += step;
                 }
             }
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,10 +216,14 @@ fn draw_world(game: &Game, video: &mut Video, ray_hits: &[RayHit]) {
             for x in 0..PIX_WIDTH {
                 let hit = &ray_hits[x as usize];
 
-                // FIXME the selected tiles don't seem to match
-                // there must be some missing step to convert from wall tile number
-                // to texture number
-                let texture = game.cache.get_texture(hit.tile as usize + 8);
+                // convert tile number to wall pic
+                // accept-the-mystery
+                let wallpic = if hit.horizontal {
+                    (hit.tile - 1) * 2
+                } else {
+                    (hit.tile - 1) * 2 + 1
+                };
+                let texture = game.cache.get_texture(wallpic as usize);
 
                 let current = match ray_hits[x as usize].height {
                     rh if rh > PIX_CENTER => PIX_CENTER,

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,7 +216,7 @@ fn draw_world(game: &Game, video: &mut Video, ray_hits: &[RayHit]) {
             for x in 0..PIX_WIDTH {
                 let hit = &ray_hits[x as usize];
                 // FIXME the selected tiles don't seem to match
-                let texture = game.cache.get_texture(hit.tile as usize+6);
+                let texture = game.cache.get_texture(hit.tile as usize+8);
 
                 let current = match ray_hits[x as usize].height {
                     rh if rh > PIX_CENTER => PIX_CENTER,

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,7 +219,7 @@ fn draw_world(game: &Game, video: &mut Video, ray_hits: &[RayHit]) {
                 // FIXME the selected tiles don't seem to match
                 // there must be some missing step to convert from wall tile number
                 // to texture number
-                let texture = game.cache.get_texture(hit.tile as usize+8);
+                let texture = game.cache.get_texture(hit.tile as usize + 8);
 
                 let current = match ray_hits[x as usize].height {
                     rh if rh > PIX_CENTER => PIX_CENTER,

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,17 +230,19 @@ fn draw_world(game: &Game, video: &mut Video, ray_hits: &[RayHit]) {
                     rh => rh,
                 };
 
-                // FIXME iterating through the texture x coords for now,
-                // until we add texture intercept logic to the ray caster
-                let xoff = (x % WALLPIC_WIDTH as u32) * WALLPIC_WIDTH as u32;
+                // tex_x is where the ray hit within the texture, indicates which part
+                // of the texture should be displayed for this given pixel column
+                // Need to multiply for width to get the correct row in the matrix
+                // for this column
+                let xoff = hit.tex_x * WALLPIC_WIDTH;
 
                 // TODO review this scaling logic, it may not be accurate enough
                 let step = WALLPIC_WIDTH as f64 / 2.0 / ray_hits[x as usize].height as f64;
                 let mut ytex = 0.0;
 
                 for y in PIX_CENTER - current..PIX_CENTER + current {
-                    let source = ytex as u32 + xoff;
-                    let color_index = texture[source as usize] as usize;
+                    let source = ytex as usize + xoff;
+                    let color_index = texture[source] as usize;
                     let mut color = video.color_map[color_index];
 
                     // divide the color by a factor of the height to get a gradient shadow effect based on distance

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,16 +215,25 @@ fn draw_world(game: &Game, video: &mut Video, ray_hits: &[RayHit]) {
 
             for x in 0..PIX_WIDTH {
                 let hit = &ray_hits[x as usize];
+
                 // FIXME the selected tiles don't seem to match
+                // there must be some missing step to convert from wall tile number
+                // to texture number
                 let texture = game.cache.get_texture(hit.tile as usize+8);
 
                 let current = match ray_hits[x as usize].height {
                     rh if rh > PIX_CENTER => PIX_CENTER,
                     rh => rh,
                 };
+
+                // FIXME iterating through the texture x coords for now,
+                // until we add texture intercept logic to the ray caster
                 let xoff = (x % 64) * 64;
+
+                // TODO review this scaling logic, it may not be accurate enough
                 let step = 32.0 / ray_hits[x as usize].height as f64;
                 let mut ytex = 0.0;
+
                 for y in PIX_CENTER - current..PIX_CENTER + current {
                     let source = ytex as u32 + xoff;
                     let color_index = texture[source as usize] as usize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,10 +228,10 @@ fn draw_world(game: &Game, video: &mut Video, ray_hits: &[RayHit]) {
 
                 // FIXME iterating through the texture x coords for now,
                 // until we add texture intercept logic to the ray caster
-                let xoff = (x % 64) * 64;
+                let xoff = (x % WALLPIC_WIDTH as u32) * WALLPIC_WIDTH as u32;
 
                 // TODO review this scaling logic, it may not be accurate enough
-                let step = 32.0 / ray_hits[x as usize].height as f64;
+                let step = WALLPIC_WIDTH as f64 / 2.0 / ray_hits[x as usize].height as f64;
                 let mut ytex = 0.0;
 
                 for y in PIX_CENTER - current..PIX_CENTER + current {

--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -19,7 +19,7 @@ const PLAYER_DIAM: i32 = 6;
 const PLAYER_LEN: f64 = 40.0;
 const FIELD_OF_VIEW: f64 = PI / 2.0;
 
-const TILE_SIZE: u32 = 4;
+const TILE_SIZE: f64 = 4.8;
 
 // FIXME this is suspicious, probably use Option or Result?
 struct Nothing;
@@ -122,7 +122,7 @@ fn draw_rays<T: RenderTarget>(map: &Map, canvas: &mut Canvas<T>, player: &Player
         let (_, _, distance, tile) = hit;
 
         let adj_distance = distance * offset.cos();
-        let ray_height = (TILE_SIZE * n_rays) as f64 / adj_distance;
+        let ray_height = TILE_SIZE * n_rays as f64 / adj_distance;
         let tex_x = ray_to_tex_coordinatinates(hit.0, hit.1, horiz);
         hits.push(RayHit {
             height: min(height, ray_height as u32),
@@ -267,7 +267,8 @@ fn ray_to_tex_coordinatinates(rx: f64, ry: f64, horizontal: bool) -> usize {
     } else {
         (ry / MAP_SCALE_H as f64).fract()
     };
-    (fract * WALLPIC_WIDTH as f64) as usize
+    // invert because wall pictures are stored flipped
+    ((1.0 - fract) * WALLPIC_WIDTH as f64) as usize
 }
 
 fn cdiv(x: f64, scale: u32, updown: f64) -> usize {

--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -30,7 +30,7 @@ pub struct RayCaster {
 
 pub struct RayHit {
     pub height: u32,
-    pub tile: Tile,
+    pub tile: u16,
     pub horizontal: bool,
 }
 
@@ -134,7 +134,7 @@ fn draw_rays<T: RenderTarget>(map: &Map, canvas: &mut Canvas<T>, player: &Player
 fn draw_ray<T: RenderTarget>(
     canvas: &mut Canvas<T>,
     player: &Player,
-    ray: (f64, f64, f64, Tile),
+    ray: (f64, f64, f64, u16),
     color: Color,
 ) {
     let (x, y, _, _) = ray;
@@ -153,12 +153,12 @@ fn cast_ray_v<T: RenderTarget>(
     _canvas: &mut Canvas<T>,
     player: &Player,
     ray_offset: f64,
-) -> (f64, f64, f64, Tile) {
+) -> (f64, f64, f64, u16) {
     let ray_angle = norm_angle(player.angle + ray_offset);
 
     //looking to the side -- cannot hit a horizontal line
     if ray_angle == ANGLE_LEFT || ray_angle == ANGLE_RIGHT {
-        return (0.0, 0.0, f64::INFINITY, Tile::Floor);
+        return (0.0, 0.0, f64::INFINITY, 0);
     }
 
     let (rx, ry, xo, yo) = if !(ANGLE_RIGHT..=ANGLE_LEFT).contains(&ray_angle) {
@@ -187,12 +187,12 @@ fn cast_ray_h<T: RenderTarget>(
     _canvas: &mut Canvas<T>,
     player: &Player,
     ray_offset: f64,
-) -> (f64, f64, f64, Tile) {
+) -> (f64, f64, f64, u16) {
     let ray_angle = norm_angle(player.angle + ray_offset);
 
     //looking up/down -- cannot hit a vertical line
     if ray_angle == ANGLE_UP || ray_angle == ANGLE_DOWN {
-        return (0.0, 0.0, f64::INFINITY, Tile::Floor);
+        return (0.0, 0.0, f64::INFINITY, 0);
     }
 
     let (rx, ry, xo, yo) = if ray_angle < ANGLE_UP {
@@ -224,15 +224,15 @@ fn follow_ray(
     y: f64,
     xo: f64,
     yo: f64,
-) -> (f64, f64, f64, Tile) {
+) -> (f64, f64, f64, u16) {
     let (mut rx, mut ry) = (x, y);
     for _ in 1..MAP_HEIGHT {
         match read_map(map, rx, ry) {
-            Ok(tile @ Tile::Wall(_)) => {
+            Ok(Tile::Wall(tile)) => {
                 return (rx, ry, distance(player, rx, ry), tile);
             }
             Err(_) => {
-                return (rx, ry, distance(player, rx, ry), Tile::Floor);
+                return (rx, ry, distance(player, rx, ry), 0);
             }
             _ => {}
         }
@@ -240,7 +240,7 @@ fn follow_ray(
         ry += yo;
     }
 
-    (rx, ry, distance(player, rx, ry), Tile::Floor)
+    (rx, ry, distance(player, rx, ry), 0)
 }
 
 fn read_map(map: &Map, x: f64, y: f64) -> Result<Tile, Nothing> {

--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -262,13 +262,17 @@ fn read_map(map: &Map, x: f64, y: f64) -> Result<Tile, Nothing> {
 /// part of the texture the ray hit.
 // TODO consider moving this over to the drawing routine instead
 fn ray_to_tex_coordinatinates(rx: f64, ry: f64, horizontal: bool) -> usize {
+    let tx = (rx / MAP_SCALE_W as f64).fract();
+    let ty = (ry / MAP_SCALE_H as f64).fract();
+
     let fract = if horizontal {
-        (rx / MAP_SCALE_W as f64).fract()
+        1.0 - tx
+    } else if tx < 0.5 {
+        ty
     } else {
-        (ry / MAP_SCALE_H as f64).fract()
+        1.0 - ty
     };
-    // invert because wall pictures are stored flipped
-    ((1.0 - fract) * WALLPIC_WIDTH as f64) as usize
+    (fract * WALLPIC_WIDTH as f64) as usize
 }
 
 fn cdiv(x: f64, scale: u32, updown: f64) -> usize {


### PR DESCRIPTION
This adds some code to the ray caster to map ray hit coordinates to texture coordinates and uses that to draw wall textures instead of plain colors. 

<img width="1072" alt="Screen Shot 2022-02-27 at 8 03 25 PM" src="https://user-images.githubusercontent.com/1040941/155903710-7478ac7b-d411-41b1-b9a8-117e2938ef01.png">
<img width="1072" alt="Screen Shot 2022-02-27 at 8 04 30 PM" src="https://user-images.githubusercontent.com/1040941/155903748-4a5731ea-5ffa-4915-b6de-1ca03e4be05c.png">

