### PR TITLE
Use the full window resolution for pixel drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rustenstein 3D
 
-Prototype Wolfenstein 3D port written in Rust. 
-* [Development story](https://tech.nextroll.com/blog/dev/2022/02/02/rustenstein.html) 
+Prototype Wolfenstein 3D port written in Rust.
+* [Development story](https://tech.nextroll.com/blog/dev/2022/02/02/rustenstein.html)
 * [Roadmap](https://github.com/AdRoll/rustenstein/projects/1)
 
 ![Gameplay](./rustenstein.gif)
@@ -16,4 +16,4 @@ The files can be found, for example, [here](https://archive.org/details/Wolfenst
 
 Run the game with:
 
-    cargo run
+    cargo run --release

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,12 +10,9 @@ pub const ANGLE_DOWN: f64 = 0.0;
 pub const ANGLE_UP: f64 = PI;
 pub const ANGLE_LEFT: f64 = 3.0 * PI / 2.0;
 pub const ANGLE_RIGHT: f64 = PI / 2.0;
-const STATUS_LINES: u32 = 40;
+pub const STATUS_LINES: u32 = 40;
 pub const BASE_WIDTH: u32 = 320;
 pub const BASE_HEIGHT: u32 = 200;
-pub const PIX_WIDTH: u32 = BASE_WIDTH;
-pub const PIX_HEIGHT: u32 = BASE_HEIGHT - STATUS_LINES;
-pub const PIX_CENTER: u32 = PIX_HEIGHT / 2;
 pub const WALLPIC_WIDTH: usize = 64;
 
 // ok this is not a constant, we may move it to an util module later, or rename this

--- a/src/ray_caster.rs
+++ b/src/ray_caster.rs
@@ -51,11 +51,11 @@ impl RayCaster {
         RayCaster { canvas: canvas_2d }
     }
 
-    pub fn tick(&mut self, player: &Player, map: &Map) -> Vec<RayHit> {
+    pub fn tick(&mut self, n_rays: u32, height: u32, player: &Player, map: &Map) -> Vec<RayHit> {
         self.canvas.set_draw_color(Color::RGB(64, 64, 64));
         self.canvas.clear();
         draw_map(map, &mut self.canvas);
-        let hits = draw_rays(map, &mut self.canvas, player);
+        let hits = draw_rays(n_rays, height, map, &mut self.canvas, player);
         draw_player(&mut self.canvas, player);
         self.canvas.present();
         hits
@@ -102,9 +102,13 @@ fn draw_player<T: RenderTarget>(canvas: &mut Canvas<T>, player: &Player) {
         .unwrap();
 }
 
-fn draw_rays<T: RenderTarget>(map: &Map, canvas: &mut Canvas<T>, player: &Player) -> Vec<RayHit> {
-    let height = PIX_HEIGHT;
-    let n_rays = PIX_WIDTH;
+fn draw_rays<T: RenderTarget>(
+    n_rays: u32,
+    height: u32,
+    map: &Map,
+    canvas: &mut Canvas<T>,
+    player: &Player,
+) -> Vec<RayHit> {
     let fov_delta = FIELD_OF_VIEW / (n_rays as f64);
     let mut hits: Vec<RayHit> = Vec::new();
     for i in 0..n_rays {


### PR DESCRIPTION
This fixes pixel distortion of the wall textures. This was produced because we were always using a 320x200 video buffer, regardless of the window resolution, and scaling it up every time we presented to the canvas.

Now the buffer has the same resolution as the window (defaults to 960x600), making the walls look better. Note that, in my laptop, the debug target is now slow at this resolution, but it works fine on a release build because of optimizations (we could look into optimizing to make it run smoothly in debug at higher resolutions).

<img width="1072" alt="Screen Shot 2022-02-28 at 5 05 44 PM" src="https://user-images.githubusercontent.com/1040941/156051054-9fa8676d-4eb3-4f74-be1a-7a8b98bae785.png">

